### PR TITLE
Add User-Agent header to avoid 403 when using httr::GET

### DIFF
--- a/R/canton_json_to_dfr.R
+++ b/R/canton_json_to_dfr.R
@@ -8,7 +8,7 @@
 #' @param index selection by index of the resource (last published = 1).
 #' @param call_res result of a previous call to the base API. Optional argument.
 #' 
-#' @importFrom httr GET http_error content
+#' @importFrom httr add_headers GET http_error content
 #' @importFrom jsonlite fromJSON
 #' @importFrom tibble tibble
 #' @importFrom purrr map
@@ -67,7 +67,7 @@ canton_json_to_dfr <- function(votedate = NULL, geolevel = "municipality", datau
   if (length(dataurl) > 1) stop("This is not a vectorised function. Only one URL can be queried at a time.")
   
   # Fetch, check and extract vote data
-  res <- httr::GET(dataurl)
+  res <- httr::GET(dataurl, httr::add_headers(`User-Agent` = "Mozilla/5.0"))
   res_data <- check_api_call(res)
   # res_data <- suppressWarnings(jsonlite::fromJSON(httr::content(res, as = "text", encoding = "UTF-8")))
   

--- a/R/swiss_json_to_dfr.R
+++ b/R/swiss_json_to_dfr.R
@@ -9,7 +9,7 @@
 #' @param language defines the language of the vote title. Options: "DE" for German, "FR" for French, "IT" for Italian or "RM" for Romansh.
 #' @param call_res result of a previous call to the base API. Optional argument.
 #' 
-#' @importFrom httr GET http_error content
+#' @importFrom httr add_headers GET http_error content
 #' @importFrom jsonlite fromJSON
 #' @importFrom tibble tibble
 #' @importFrom purrr map_chr map
@@ -67,7 +67,7 @@ swiss_json_to_dfr <- function(votedate = NULL, geolevel = "municipality", dataur
   if (length(dataurl) > 1) stop("This is not a vectorised function. Only one URL can be queried at a time.")
   
   # Fetch, check and extract vote data
-  res <- httr::GET(dataurl)
+  res <- httr::GET(dataurl, httr::add_headers(`User-Agent` = "Mozilla/5.0"))
   res_data <- check_api_call(res)
   # res_data <- suppressWarnings(jsonlite::fromJSON(httr::content(res, as = "text", encoding = "UTF-8")))
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,14 +76,14 @@ check_theme <- function(theme, available_themes) {
   
 }
 
-#' @importFrom httr GET
+#' @importFrom httr add_headers GET
 #'
 #' @noRd
 call_api_base <- function(geolevel = "national") {
   
   # Call
-  if (geolevel == "national") res <- httr::GET("https://opendata.swiss/api/3/action/package_show?id=echtzeitdaten-am-abstimmungstag-zu-eidgenoessischen-abstimmungsvorlagen")
-  if (geolevel == "canton") res <- httr::GET("https://opendata.swiss/api/3/action/package_show?id=echtzeitdaten-am-abstimmungstag-zu-kantonalen-abstimmungsvorlagen")
+  if (geolevel == "national") res <- httr::GET("https://opendata.swiss/api/3/action/package_show?id=echtzeitdaten-am-abstimmungstag-zu-eidgenoessischen-abstimmungsvorlagen", httr::add_headers(`User-Agent` = "Mozilla/5.0"))
+  if (geolevel == "canton") res <- httr::GET("https://opendata.swiss/api/3/action/package_show?id=echtzeitdaten-am-abstimmungstag-zu-kantonalen-abstimmungsvorlagen", httr::add_headers(`User-Agent` = "Mozilla/5.0"))
   
   # Check
   check_api_call(res)
@@ -93,13 +93,13 @@ call_api_base <- function(geolevel = "national") {
   
 }
 
-#' @importFrom httr GET http_error
+#' @importFrom httr add_headers GET http_error
 #'
 #' @noRd
 call_api_geodata <- function(){
   
   # Call
-  res <- httr::GET("https://opendata.swiss/api/3/action/package_show?id=geodaten-zu-den-eidgenoessischen-abstimmungsvorlagen")
+  res <- httr::GET("https://opendata.swiss/api/3/action/package_show?id=geodaten-zu-den-eidgenoessischen-abstimmungsvorlagen", httr::add_headers(`User-Agent` = "Mozilla/5.0"))
   
   # Return
   return(res)


### PR DESCRIPTION
While trying to fetch data from the opendata.swiss API using `httr::GET()`, I consistently received a `403 Forbidden` error.

After investigating, I think that the API server rejects requests without a proper User-Agent header.

To resolve this, I added the following header to the request:

```r
add_headers(`User-Agent` = "Mozilla/5.0")
